### PR TITLE
"Service to handle pickled python from multyvac"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 runner-py2
 ==========
 
-Service to handle pickled code from cloudpipe.
+Service to handle pickled code from multyvac.
 
 Full example:
 


### PR DESCRIPTION
The contract is between multyvac and this container/service, not cloudpipe itself. We're just adhering to their spec.